### PR TITLE
Implement NewNoCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ information and this also makes it better-suited for serving static assets:
 * Internal errors (such as permission errors) are not exposed as HTTP errors;
   any internal error other than "not found" becomes a 500.
 
+## Local development with `NewNoCache`
+
+When running a server for local development, having assets be cached for even a
+minute is generally undesirable. For this use case, a "no-cache" `Server` can be
+constructed using `NewNoCache`. A `Server` created this way serves files with
+`Cache-Control: no-cache` so that the browser will revalidate the assets on
+every page load.
+
 ## Caveats
 
 The assetserver package is designed specifically to serve static web assets that

--- a/assetserver_test.go
+++ b/assetserver_test.go
@@ -94,6 +94,11 @@ func TestServeHTTPEmbed(t *testing.T) {
 	webtest.TestHandler(t, "testdata/servehttp.txt", s)
 }
 
+func TestServeHTTPNoCache(t *testing.T) {
+	s := NewNoCache(os.DirFS("testdata/assets"))
+	webtest.TestHandler(t, "testdata/nocache.txt", s)
+}
+
 // The interaction of redirects and http.StripPrefix is a bit subtle, so test it
 // explicitly.
 func TestStripPrefix(t *testing.T) {

--- a/testdata/nocache.txt
+++ b/testdata/nocache.txt
@@ -1,0 +1,27 @@
+GET /
+code == 404
+
+GET /noexist.txt
+code == 404
+
+GET /a.js
+trimbody ==
+	ajs
+header Cache-Control == no-cache
+header ETag == "sI22qapGJ0"
+header Content-Type contains text/javascript
+
+GET /a.js
+reqheader If-None-Match "sI22qapGJ0"
+header Cache-Control == no-cache
+code == 304
+
+GET /a.sI22qapGJ0.js
+trimbody ==
+	ajs
+header Cache-Control == no-cache
+header ETag == "sI22qapGJ0"
+header Content-Type contains text/javascript
+
+GET /a.sI22qapGJ1.js
+code == 404


### PR DESCRIPTION
For local dev servers, you generally want files to be served with Cache-Control: no-cache so page refreshes always get the latest static assets.