### PR TITLE
Change Tag to a no-op for a no-cache server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ constructed using `NewNoCache`. A `Server` created this way serves files with
 `Cache-Control: no-cache` so that the browser will revalidate the assets on
 every page load.
 
+Additionally, tagged names can be undesirable in development environments
+because these names interfere with developer tools that reload assets (such as
+CSS files) when they change. Therefore, for a no-cache server, the `Tag` method
+returns the untagged path.
+
 ## Caveats
 
 The assetserver package is designed specifically to serve static web assets that

--- a/assetserver_test.go
+++ b/assetserver_test.go
@@ -45,6 +45,44 @@ func TestTag(t *testing.T) {
 	}
 }
 
+func TestTagNoCache(t *testing.T) {
+	s := NewNoCache(os.DirFS("testdata/assets"))
+	for _, name := range []string{
+		"d/style.css",
+		"/d/style.css",
+		"a.js",
+		"b.min.js",
+		"d/sub/noext",
+	} {
+		got, err := s.Tag(name)
+		if err != nil {
+			t.Fatalf("Tag(%q): %s", name, err)
+		}
+		if got != name {
+			t.Errorf("Tag(%q): got %q; want %[1]q", name, got)
+		}
+	}
+}
+
+func TestTagError(t *testing.T) {
+	s := New(os.DirFS("testdata/assets"))
+	// A no-cache server should give back the same errors even though it
+	// behaves as a no-op in the normal case.
+	noCache := NewNoCache(os.DirFS("testdata/assets"))
+	for _, name := range []string{
+		"nonexistent.css",
+		"d",
+		"d/sub",
+	} {
+		if _, err := s.Tag(name); err == nil {
+			t.Fatalf("Tag(%q): got nil error", name)
+		}
+		if _, err := noCache.Tag(name); err == nil {
+			t.Fatalf("no-cache Tag(%q): got nil error", name)
+		}
+	}
+}
+
 func TestRemoveTag(t *testing.T) {
 	for _, tt := range []struct {
 		s    string


### PR DESCRIPTION
When using a no-cache server, I think it's generally desirable (or at least perfectly acceptable) to not use tagging. It's most convenient to implement this by having Tag itself be a no-op rather than having the caller provide a no-op function.

Additionally, by having Tag actually read the file even in the no-cache case, we can catch and loudly report errors where the user passed a bad path to Tag. This removes a difference in the dev vs. prod behavior that could make it easier to not notice bugs in the dev environment.